### PR TITLE
Add filter for nullable integers

### DIFF
--- a/Dewdrop/Db/Field/InputFilterBuilder.php
+++ b/Dewdrop/Db/Field/InputFilterBuilder.php
@@ -12,6 +12,7 @@ namespace Dewdrop\Db\Field;
 
 use Dewdrop\Db\Field;
 use Dewdrop\Filter\NullableDbBoolean as NullableDbBooleanFilter;
+use Dewdrop\Filter\NullableDbInteger as NullableDbIntegerFilter;
 use Zend\Filter;
 use Zend\InputFilter\Input;
 use Zend\Validator;
@@ -166,7 +167,12 @@ class InputFilterBuilder
      */
     protected function attachForInteger(Input $input)
     {
-        $input->getFilterChain()->attach(new Filter\Int());
+        if ($this->metadata['NULLABLE']) {
+            $input->getFilterChain()->attach(new NullableDbIntegerFilter());
+        } else {
+            $input->getFilterChain()->attach(new Filter\Int());
+        }
+        
         $input->getValidatorChain()->attach(new \Zend\I18n\Validator\Int());
 
         return $input;

--- a/Dewdrop/Filter/NullableDbInteger.php
+++ b/Dewdrop/Filter/NullableDbInteger.php
@@ -20,9 +20,7 @@ class NullableDbInteger extends AbstractFilter
 {
     /**
      * For empty strings (think HTTP requests, where everything is a string), or
-     * actual nulls, we return null.  If not, we return the value cast to an int,
-     * which is friendlier than dragging around the actual boolean because those
-     * don't play nice with the DBs.
+     * actual nulls, we return null.  If not, we return the value cast to an int.
      *
      * @param mixed $value
      * @return int|null

--- a/Dewdrop/Filter/NullableDbInteger.php
+++ b/Dewdrop/Filter/NullableDbInteger.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Dewdrop
+ *
+ * @link      https://github.com/DeltaSystems/dewdrop
+ * @copyright Delta Systems (http://deltasys.com)
+ * @license   https://github.com/DeltaSystems/dewdrop/LICENSE
+ */
+
+namespace Dewdrop\Filter;
+
+use Zend\Filter\AbstractFilter;
+
+/**
+ * This filter is intended to assist with DB integer fields that are allowed to
+ * be nullable.
+ */
+class NullableDbInteger extends AbstractFilter
+{
+    /**
+     * For empty strings (think HTTP requests, where everything is a string), or
+     * actual nulls, we return null.  If not, we return the value cast to an int,
+     * which is friendlier than dragging around the actual boolean because those
+     * don't play nice with the DBs.
+     *
+     * @param mixed $value
+     * @return int|null
+     */
+    public function filter($value)
+    {
+        if (null === $value || '' === $value) {
+            $out = null;
+        } else {
+            $out = (int) $value;
+        }
+
+        return $out;
+    }
+}


### PR DESCRIPTION
Currently a nullable integer field gets filtered to a 0, which causes an error for nullable fields that are foreign keys.