### PR TITLE
digit filter not allowing decimal point

### DIFF
--- a/Dewdrop/Db/Field/InputFilterBuilder.php
+++ b/Dewdrop/Db/Field/InputFilterBuilder.php
@@ -186,7 +186,6 @@ class InputFilterBuilder
      */
     protected function attachForFloat(Input $input)
     {
-        $input->getFilterChain()->attach(new Filter\Digits());
         $input->getValidatorChain()->attach(new \Zend\I18n\Validator\Float());
 
         return $input;


### PR DESCRIPTION
Looks like that digits filter doesn't allow the decimal point and the validator should be sufficient anyway.