### PR TITLE
update phpdocumentor to 2.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "jdorn/sql-formatter": "1.2.*",
         "squizlabs/php_codesniffer": "1.*",
         "php": ">=5.4.0",
-        "phpdocumentor/phpdocumentor": "2.7.*",
+        "phpdocumentor/phpdocumentor": "2.*",
         "phpoffice/phpexcel": "1.8.*",
         "phpunit/dbunit": "1.*",
         "phpunit/phpunit": "3.*",


### PR DESCRIPTION
update phpdocumentor to stop these warnings:

Package phpdocumentor/template-abstract is abandoned, you should avoid using it. No replacement was suggested.
Package phpdocumentor/template-responsive is abandoned, you should avoid using it. No replacement was suggested.