### PR TITLE
Multiple Select: make name be array

### DIFF
--- a/Dewdrop/View/Helper/Select.php
+++ b/Dewdrop/View/Helper/Select.php
@@ -99,6 +99,10 @@ class Select extends AbstractHelper
 
         $value = (array) $value;
 
+        if (count($value) > 1) {
+            $name .= '[]';
+        }
+
         return $this->partial(
             'select.phtml',
             [

--- a/tests/Dewdrop/View/Helper/SelectTest.php
+++ b/tests/Dewdrop/View/Helper/SelectTest.php
@@ -46,7 +46,7 @@ class SelectTest extends BaseTestCase
             )
         );
 
-        $this->assertMatchesDomQuery('select[name="my_select"]', $out);
+        $this->assertMatchesDomQuery('select[name="my_select[]"]', $out);
         $this->assertMatchesDomQuery('option[value="1"]', $out);
         $this->assertMatchesDomQuery('option[value="2"]', $out);
 


### PR DESCRIPTION
Select name property should automatically be an array if there are multiple selected values.